### PR TITLE
Restore support for 15w40b in node-minecraft-data

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,19 @@ var data={
     windows: require('./minecraft-data/data/1.8/windows'),
     version: require('./minecraft-data/data/1.8/version')
   },
+  "15w40b":{
+    blocks:require('./minecraft-data/data/1.9/blocks'),
+    biomes: require('./minecraft-data/data/1.9/biomes'),
+    effects: require('./minecraft-data/data/1.9/effects'),
+    items: require('./minecraft-data/data/1.9/items'),
+    recipes: require('./minecraft-data/data/1.9/recipes'),
+    instruments: require('./minecraft-data/data/1.9/instruments'),
+    materials: require('./minecraft-data/data/1.9/materials'),
+    entities: require('./minecraft-data/data/1.9/entities'),
+    protocol: require('./minecraft-data/data/15w40b/protocol'),
+    windows: require('./minecraft-data/data/1.9/windows'),
+    version: require('./minecraft-data/data/15w40b/version')
+  },
   "1.9":{
     blocks:require('./minecraft-data/data/1.9/blocks'),
     biomes: require('./minecraft-data/data/1.9/biomes'),


### PR DESCRIPTION
Requires https://github.com/PrismarineJS/minecraft-data/pull/109 - re-adds 15w40b snapshot support (protocol only, other data is shared with '1.9'). Client has to specifically ask for it with `require('minecraft-data')('15w40b')`, "1.9" will get the 16w04a snapshot.