### PR TITLE
[WIP] Version loading improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,9 +30,9 @@ function toMajor(mcVersion,preNetty)
   if(versionsByMinecraftVersion[mcVersion])
     return versionsByMinecraftVersion[mcVersion].majorVersion;
   if(preNetty && preNettyVersionsByProtocolVersion[mcVersion])
-    return preNettyVersionsByProtocolVersion[mcVersion][0].majorVersion;
+    return toMajor(preNettyVersionsByProtocolVersion[mcVersion][0].minecraftVersion);
   if(!preNetty && postNettyVersionsByProtocolVersion[mcVersion])
-    return postNettyVersionsByProtocolVersion[mcVersion][0].majorVersion;
+    return toMajor(postNettyVersionsByProtocolVersion[mcVersion][0].minecraftVersion);
 }
 
 module.exports.versions=protocolVersions;


### PR DESCRIPTION
Relevant discussion: https://github.com/PrismarineJS/node-minecraft-protocol/issues/345

Attempt at resolving majorVersion ambiguity

Before:

```
> require('minecraft-data')('15w40b').version
{ version: 76, minecraftVersion: '15w40b', majorVersion: '1.9' }
> require('minecraft-data')(76).version
{ version: 99, minecraftVersion: '16w05b', majorVersion: '1.9' }
```

After:

```
> require('minecraft-data')('15w40b').version
{ version: 76, minecraftVersion: '15w40b', majorVersion: '1.9' }
> require('minecraft-data')(76).version
{ version: 76, minecraftVersion: '15w40b', majorVersion: '1.9' }
```

may need more changes and/or testing (remove the `majorVersion` field of protocolVersions entirely?)