### PR TITLE
Add 1.7 protocol support in node-minecraft-data

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,19 +42,16 @@ module.exports.postNettyVersionsByProtocolVersion=postNettyVersionsByProtocolVer
 
 var data={
   "1.7":{
-    blocks:require('./minecraft-data/data/1.8/blocks'),
-    biomes: require('./minecraft-data/data/1.8/biomes'),
-    effects: require('./minecraft-data/data/1.8/effects'),
-    items: require('./minecraft-data/data/1.8/items'),
-    recipes: require('./minecraft-data/data/1.8/recipes'),
-    instruments: require('./minecraft-data/data/1.8/instruments'),
-    materials: require('./minecraft-data/data/1.8/materials'),
-    entities: require('./minecraft-data/data/1.8/entities'),
-
+    blocks:require('./minecraft-data/data/1.7/blocks'),
+    biomes: require('./minecraft-data/data/1.7/biomes'),
+    effects: require('./minecraft-data/data/1.7/effects'),
+    items: require('./minecraft-data/data/1.7/items'),
+    recipes: require('./minecraft-data/data/1.8/recipes'), // TODO: 1.7 recipes
+    instruments: require('./minecraft-data/data/1.7/instruments'),
+    materials: require('./minecraft-data/data/1.7/materials'),
+    entities: require('./minecraft-data/data/1.7/entities'),
     protocol: require('./minecraft-data/data/1.7/protocol'),
-
-    windows: require('./minecraft-data/data/1.8/windows'),
-
+    windows: require('./minecraft-data/data/1.7/windows'),
     version: require('./minecraft-data/data/1.7/version')
   },
   "1.8":{

--- a/index.js
+++ b/index.js
@@ -41,6 +41,22 @@ module.exports.preNettyVersionsByProtocolVersion=preNettyVersionsByProtocolVersi
 module.exports.postNettyVersionsByProtocolVersion=postNettyVersionsByProtocolVersion;
 
 var data={
+  "1.7":{
+    blocks:require('./minecraft-data/data/1.8/blocks'),
+    biomes: require('./minecraft-data/data/1.8/biomes'),
+    effects: require('./minecraft-data/data/1.8/effects'),
+    items: require('./minecraft-data/data/1.8/items'),
+    recipes: require('./minecraft-data/data/1.8/recipes'),
+    instruments: require('./minecraft-data/data/1.8/instruments'),
+    materials: require('./minecraft-data/data/1.8/materials'),
+    entities: require('./minecraft-data/data/1.8/entities'),
+
+    protocol: require('./minecraft-data/data/1.7/protocol'),
+
+    windows: require('./minecraft-data/data/1.8/windows'),
+
+    version: require('./minecraft-data/data/1.7/version')
+  },
   "1.8":{
     blocks:require('./minecraft-data/data/1.8/blocks'),
     biomes: require('./minecraft-data/data/1.8/biomes'),


### PR DESCRIPTION
Corresponding change to node-minecraft-data for https://github.com/PrismarineJS/minecraft-data/pull/104 1.7 protocol 5

Currently reuses some 1.8 data since it is not all provided for 1.7 by https://github.com/PrismarineJS/minecraft-data/pull/104, only the protocol and version