### PR TITLE
Chore/export ts types

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "main": "index.js",
   "tonicExampleFilename": "example.js",
   "scripts": {
-    "test": "require-self && ./bin/generate_data.js && npm run lint && tsc typings/test-typings.ts && node typings/test-typings.js && mocha",
+    "generate:types": "node typings/generate-typings.js",
+    "generate:data": "./bin/generate_data.js",
+    "test:types": "tsc typings/test-typings && node typings/test-typings.js",
+    "test": "require-self && npm run generate:data && npm run lint && npm run test:types && mocha",
     "lint": "standard",
-    "prepublish": "require-self && ./bin/generate_data.js && node typings/generate-typings.js",
+    "prepublish": "require-self && npm run generate:data && npm run generate:types",
     "fix": "standard --fix"
   },
   "standard": {
@@ -30,7 +33,7 @@
     "url": "https://github.com/PrismarineJS/node-minecraft-data/issues"
   },
   "devDependencies": {
-    "@types/node": "^14.0.1",
+    "@types/node": "^14.0.14",
     "json-schema-to-typescript": "^9.1.0",
     "mocha": "^8.0.1",
     "require-self": "^0.2.3",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,11 +9,10 @@
     "strictNullChecks": false,
     "strictFunctionTypes": true,
     "forceConsistentCasingInFileNames": true,
-    "types": []
+    "types": ["node"]
   },
   "files": [
     "index.d.ts",
-    "tests/minecraft-data.ts",
     "typings/test-typings.ts"
   ]
 }

--- a/typings/generate-typings.js
+++ b/typings/generate-typings.js
@@ -29,7 +29,8 @@ async function generate () {
 
   typingString += templateTypings.split('\n').map(line => '  ' + line).join('\n')
   typingString += '\n}\n\n' // Close namespace
-  typingString += 'export = MinecraftData.GetMinecraftData'
+  typingString += 'declare function MinecraftData(version: string | number): MinecraftData.IndexedData;\n'
+  typingString += 'export = MinecraftData'
 
   fs.writeFileSync(path.resolve(__dirname, '../index.d.ts'), typingString)
 }

--- a/typings/index-template.d.ts
+++ b/typings/index-template.d.ts
@@ -1,15 +1,15 @@
 
-interface VersionSet {
+export interface VersionSet {
   pc: { [version: string]: Version };
   pe: { [version: string]: Version };
 }
 
-interface SupportedVersions {
+export interface SupportedVersions {
   pc: string[];
   pe: string[];
 }
 
-interface Schemas {
+export interface Schemas {
   biomes: any;
   blocks: any;
   effects: any;
@@ -24,7 +24,7 @@ interface Schemas {
   windows: any;
 }
 
-interface IndexedData {
+export interface IndexedData {
   blocks: { [id: number]: Block; };
   blocksByName: { [name: string]: Block; };
   blocksArray: Block[];
@@ -73,12 +73,9 @@ interface IndexedData {
   language: { [key: string]: string };
 }
 
-const GetMinecraftData: {
-  (version: string | number): IndexedData;
-  versions: Version[];
-  versionsByMinecraftVersion: VersionSet;
-  preNettyVersionsByProtocolVersion: VersionSet;
-  postNettyVersionsByProtocolVersion: VersionSet;
-  supportedVersions: SupportedVersions;
-  schemas: Schemas;
-}
+const versions: Version[];
+const versionsByMinecraftVersion: VersionSet;
+const preNettyVersionsByProtocolVersion: VersionSet;
+const postNettyVersionsByProtocolVersion: VersionSet;
+const supportedVersions: SupportedVersions;
+const schemas: Schemas;

--- a/typings/test-typings.ts
+++ b/typings/test-typings.ts
@@ -1,5 +1,10 @@
 import getMcData = require('../');
 const mcData = getMcData('1.8.8');
+import { IndexedData } from '../'
+
+const test: Partial<IndexedData> = {
+  type: 'test'
+}
 
 console.log(mcData.blocksByName['stone']);
 console.log(mcData.windows['minecraft:brewing_stand']);


### PR DESCRIPTION
Refactored generation and types template a bit to allow consumer not only import main function but also types used with it

Before, if one wanted to get IndexedData type they had to do following:

```ts
import getMcData = require('minecraft-data')

type IndexedData = ReturnType<typeof getMcData>
```

Now one can import IndexedData like so:

```ts
import { IndexedData } from 'minecraft-data'
```

Those changes are backwards-compatible and shouldn't break anything for typescript users.
I've also split PR in two commits, if you prefer previous structure for npm scripts I can omit a600345 from this PR.