### PR TITLE
Update package.json->scripts->generate:data to use node.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "tonicExampleFilename": "example.js",
   "scripts": {
     "generate:types": "node typings/generate-typings.js",
-    "generate:data": "./bin/generate_data.js",
+    "generate:data": "node bin/generate_data.js",
     "test:types": "tsc typings/test-typings && node typings/test-typings.js",
     "test": "require-self && npm run generate:data && npm run lint && npm run test:types && mocha",
     "lint": "standard",


### PR DESCRIPTION
Kept getting errors when using npm install and had to manually execute bin/generate_data.js.  Not sure if there was a reason for the script to not call node.