### PR TITLE
Non-exclusively prefer release versions over snapshots when determining version from protocol ID

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [14.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ data.js
 package-lock.json
 index.d.ts
 typings/test-typings.js
+.vscode

--- a/index.js
+++ b/index.js
@@ -60,10 +60,11 @@ function toMajor (mcVersion, preNetty, typeArg) {
   } else if (preNetty && preNettyVersionsByProtocolVersion[type][version]) {
     return toMajor(preNettyVersionsByProtocolVersion[type][version][0].minecraftVersion, preNetty, type)
   } else if (!preNetty && postNettyVersionsByProtocolVersion[type][version]) {
-    const latest = postNettyVersionsByProtocolVersion[type][version].filter((el) => {
+    const versions = postNettyVersionsByProtocolVersion[type][version]
+    const noSnaps = versions.filter((el) => {
       return !/[a-zA-Z]/g.test(el.minecraftVersion)
-    })[0]
-    return toMajor(latest.minecraftVersion, preNetty, type)
+    })
+    return toMajor(noSnaps[0]?.minecraftVersion ?? versions[0].minecraftVersion, preNetty, type)
   } else if (versionsByMajorVersion[type][version]) {
     majorVersion = versionsByMajorVersion[type][version].minecraftVersion
   }


### PR DESCRIPTION
This might be a fix for https://github.com/PrismarineJS/node-minecraft-data/issues/104, but is a bug in any case as we shouldn't throw an error if a valid version exists