### PR TITLE
fix: use correct typing for Recipes

### DIFF
--- a/typings/index-template.d.ts
+++ b/typings/index-template.d.ts
@@ -61,7 +61,7 @@ export interface IndexedData {
     biomes: { [id: number]: Biome; };
     biomesArray: Biome[];
 
-    recipes: { [id: number]: Recipe; };
+    recipes: { [id: number]: Recipe[]; };
 
     instruments: { [id: number]: Instrument; };
     instrumentsArray: Instrument[];


### PR DESCRIPTION
The `recipes` are an `Array<Recipe>` and not a single `Recipe` for each id.

fixes #114