### PR TITLE
Merge data from protocolVersions.json and version.json in .version object

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -180,6 +180,10 @@ the version type, currently 'pc' or 'bedrock'
 
 the major version (example : 1.8), also the name of the minecraft-data version
 
+### minecraft-data.version.dataVersion
+
+"Data version" for this Minecraft version, used for example when writing chunks to disk
+
 ### minecraft-data.version.< (other)
 Returns true if the current version is less than than the `other` version's dataVersion
 

--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ function Version (type, version, majorVersion) {
     const ver = versions[version]
     versions[ver.majorVersion] = versions[ver.majorVersion] || ver
   }
+
+  // merge in data from protocolVersions.json if it exists
+  Object.assign(this, versions[version])
+
   // TODO: Data for Minecraft classic is missing in protocolVersions.json, move this to its own type ?
   const v1 = versions[version]?.dataVersion ?? 0
   const raise = other => { throw new RangeError(`Version '${other}' not found in [${Object.keys(versions).join(' ; ')}] for ${type}`) }

--- a/index.js
+++ b/index.js
@@ -30,11 +30,11 @@ function Version (type, version, majorVersion) {
     const ver = versions[version]
     versions[ver.majorVersion] = versions[ver.majorVersion] || ver
   }
-  
-  this.dataVersion = versions[version].dataVersion
+
+  this.dataVersion = versions[version]?.dataVersion
 
   // TODO: Data for Minecraft classic is missing in protocolVersions.json, move this to its own type ?
-  const v1 = versions[version]?.dataVersion ?? 0
+  const v1 = this.dataVersion ?? 0
   const raise = other => { throw new RangeError(`Version '${other}' not found in [${Object.keys(versions).join(' ; ')}] for ${type}`) }
   this['>='] = other => versions[other] ? v1 >= versions[other].dataVersion : raise(other)
   this['>'] = other => versions[other] ? v1 > versions[other].dataVersion : raise(other)

--- a/index.js
+++ b/index.js
@@ -30,9 +30,8 @@ function Version (type, version, majorVersion) {
     const ver = versions[version]
     versions[ver.majorVersion] = versions[ver.majorVersion] || ver
   }
-
-  // merge in data from protocolVersions.json if it exists
-  Object.assign(this, versions[version])
+  
+  this.dataVersion = versions[version].dataVersion
 
   // TODO: Data for Minecraft classic is missing in protocolVersions.json, move this to its own type ?
   const v1 = versions[version]?.dataVersion ?? 0


### PR DESCRIPTION
This exposes data like the DataVersion (which is in protocolVersions.json) which would previously need to be looked up with the static object exports inside the .version object

```js
const mcd = require('minecraft-data')('pc_1.18')
console.log(mcd.version.DataVersion) // now works
```