### PR TITLE
Alias versions that end in .0 to a version without the ending .0

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,9 +27,12 @@ types.forEach(function (type) {
 function Version (type, version, majorVersion) {
   const versions = versionsByMinecraftVersion[type]
   // Allows comparisons against majorVersion even if `other` is not present in the versions.json (e.g. 1.17.0 exists but not 1.17)
-  for (const version in versions) {
-    const ver = versions[version]
-    versions[ver.majorVersion] = versions[ver.majorVersion] || ver
+  for (const majorMinorPatchVersion in versions) {
+    const versionObj = versions[majorMinorPatchVersion]
+    // 1.17.0 === 1.17, so let's add explicit logic for that 
+    if (versionObj.minecraftVersion.endsWith('.0')) {
+      versions[versionObj.majorVersion] = versionObj
+    }
   }
 
   this.dataVersion = versions[version]?.dataVersion


### PR DESCRIPTION
This used to be implicit, but I guess it broke and caused issues in prismarine-block, much better to have this be explicit