### PR TITLE
Fix `foodsByFoodPoints` and `foodsBySaturation`

### DIFF
--- a/lib/indexes.js
+++ b/lib/indexes.js
@@ -37,8 +37,8 @@ module.exports = function (mcData) {
 
     foodsById: indexer.buildIndexFromArray(mcData.foods, 'id'),
     foodsByName: indexer.buildIndexFromArray(mcData.foods, 'name'),
-    foodsByFoodPoints: indexer.buildIndexFromArray(mcData.foods, 'foodPoints'),
-    foodsBySaturation: indexer.buildIndexFromArray(mcData.foods, 'saturation'),
+    foodsByFoodPoints: indexer.buildIndexFromArrayNonUnique(mcData.foods, 'foodPoints'),
+    foodsBySaturation: indexer.buildIndexFromArrayNonUnique(mcData.foods, 'saturation'),
 
     windowsById: indexer.buildIndexFromArray(mcData.windows, 'id'),
     windowsByName: indexer.buildIndexFromArray(mcData.windows, 'name'),

--- a/typings/index-template.d.ts
+++ b/typings/index-template.d.ts
@@ -109,8 +109,8 @@ export interface IndexedData {
     foods: { [id: number]: Food; };
     foodsByName: { [name: string]: Food; };
     foodsArray: Food[];
-    foodsByFoodPoints: { [foodPoints: number]: Food; };
-    foodsBySaturation: { [saturation: number]: Food; };
+    foodsByFoodPoints: { [foodPoints: number]: Food[]; };
+    foodsBySaturation: { [saturation: number]: Food[]; };
 
     biomes: { [id: number]: Biome; };
     biomesArray: Biome[];


### PR DESCRIPTION
This PR changes `foodsByFoodPoints` and `foodsBySaturation` to return an array of all food with the given foodPoints/saturation (respectively) rather than a single entry.

Closes #202