### PR TITLE
Fix entitiesById being undefined

### DIFF
--- a/lib/indexes.js
+++ b/lib/indexes.js
@@ -23,6 +23,7 @@ module.exports = function (mcData) {
     enchantmentsByName: indexer.buildIndexFromArray(mcData.enchantments, 'name'),
 
     entitiesByName: indexer.buildIndexFromArray(mcData.entities, 'name'),
+    entitiesById: indexer.buildIndexFromArray(mcData.entities, 'id'),
     mobsById: mcData.entities === undefined
       ? undefined
       : indexer.buildIndexFromArray(mcData.entities.filter(e => e.type === 'mob'), 'id'),


### PR DESCRIPTION
https://github.com/PrismarineJS/node-minecraft-data/blob/d3f23eadca290ecf991f1ee9b58ac241e3a66fec/lib/loader.js#L40 is currently undefined, already documented in https://github.com/PrismarineJS/node-minecraft-data/blob/master/doc/api.md#mcdataentities