### PR TITLE
Fix supportFeature for single-version features

### DIFF
--- a/lib/supportsFeature.js
+++ b/lib/supportsFeature.js
@@ -35,7 +35,8 @@ module.exports = (versionObj, allVersions) => {
         }
       }
     } else {
-      const [minVer, maxVer] = feature.versions
+      const minVer = feature.versions[0]
+      const maxVer = feature.versions[1] || minVer
       map[featureName] = isVersionInRange(minVer, maxVer)
     }
   }


### PR DESCRIPTION
supportFeature will fail if a feature does not have more than one version set. This can currently be circumvented by setting the minimum and maximum version to the same.

This PR "fixes" this to make minecraft-data itself a bit cleaner