### PR TITLE
fix: resolve issues with types

### DIFF
--- a/typings/index-template.d.ts
+++ b/typings/index-template.d.ts
@@ -167,7 +167,7 @@ export interface IndexedData {
 
   attributes: { [resource: string]: string }
   attributesByName: { [name: string]: string }
-  attributesArray: []
+  attributesArray: Attribute[]
 
   commands: {}
 
@@ -177,11 +177,9 @@ export interface IndexedData {
 
   language: { [key: string]: string }
 
-  blockLoot: { [id: number]: BlockLoot }
-  blockLootByName: { [name: string]: BlockLoot }
+  blockLoot: { [name: string]: BlockLoot }
 
-  entityLoot: { [id: number]: EntityLoot }
-  entityLootByName: { [name: string]: EntityLoot }
+  entityLoot: { [name: string]: EntityLoot }
 
   mapIcons: { [id: number]: MapIcon }
   mapIconsByName: { [name: string]: MapIcon }

--- a/typings/index-template.d.ts
+++ b/typings/index-template.d.ts
@@ -177,9 +177,9 @@ export interface IndexedData {
 
   language: { [key: string]: string }
 
-  blockLoot: { [name: string]: BlockLoot }
+  blockLoot: { [name: string]: BlockLootEntry }
 
-  entityLoot: { [name: string]: EntityLoot }
+  entityLoot: { [name: string]: EntityLootEntry }
 
   mapIcons: { [id: number]: MapIcon }
   mapIconsByName: { [name: string]: MapIcon }


### PR DESCRIPTION
This PR makes the following corrections:

* Adds the correct type to `attributesArray`
* Marks `blockLoot` and `entityLoot` as being indexed by name (a string)
* Correct `blockLoot` and `entityLoot` value types
* Removes `blockLootByName` and `entityLootByName` as they do not exist

Edit: this closes #298.