### PR TITLE
Fixup typings

### DIFF
--- a/typings/index-template.d.ts
+++ b/typings/index-template.d.ts
@@ -108,7 +108,10 @@ export interface IndexedData {
    * Bedrock edition only
    */
   blockStates?: { name: string; states: object; version: number }[]
-  blockCollisionShapes: { blocks: { [name: string]: number[] }; shapes: { [id: number]: [number[]] } }
+  /**
+   * id is the shape id of the block converted to a string
+   */
+  blockCollisionShapes: { blocks: { [name: string]: number | number[] }; shapes: { [id: string]: [number[]] } }
 
   loginPacket: LoginPacket
 


### PR DESCRIPTION
The typings for block collisions were incorrect, this fixes them.