### PR TITLE
fix: add `supportType` type

### DIFF
--- a/typings/generate-typings.js
+++ b/typings/generate-typings.js
@@ -1,6 +1,7 @@
 const { compileFromFile } = require('json-schema-to-typescript')
 const path = require('path')
 const fs = require('fs')
+const features = require('../minecraft-data/data/pc/common/features.json')
 
 const templateTypings = fs.readFileSync(path.resolve(__dirname, './index-template.d.ts'), 'utf8')
 
@@ -31,6 +32,26 @@ async function generate () {
     .split('\n')
     .map((line) => '  ' + line)
     .join('\n')
+
+  // #region supports features
+  typingString += '\n\n  export interface SupportsFeature {\n'
+  // prevent duplicates, use last feature with the same name
+  const featureNames = features.map(feature => feature.name)
+  const featuresUnique = features.filter(({ name }, i) => featureNames.lastIndexOf(name) === i);
+  for (const feature of featuresUnique) {
+    const versionsRange = feature.values
+      ? ''
+      : feature.version
+        ? feature.version
+        : feature.versions.join(' - ')
+
+    const valueType = feature.values ? feature.values.map(({ value }) => JSON.stringify(value)).join(' | ') : 'boolean'
+
+    typingString += '    /**' + (versionsRange && ` \`${versionsRange}\``) + '\n' + '     * ' + feature.description + ' */\n'
+    typingString += '    "' + feature.name.replaceAll('"', '\\"') + `": ${valueType};\n`
+  }
+  typingString += '  }\n\n'
+  // #endregion
 
   typingString += templateTypings
     .split('\n')

--- a/typings/generate-typings.js
+++ b/typings/generate-typings.js
@@ -37,7 +37,7 @@ async function generate () {
   typingString += '\n\n  export interface SupportsFeature {\n'
   // prevent duplicates, use last feature with the same name
   const featureNames = features.map(feature => feature.name)
-  const featuresUnique = features.filter(({ name }, i) => featureNames.lastIndexOf(name) === i);
+  const featuresUnique = features.filter(({ name }, i) => featureNames.lastIndexOf(name) === i)
   for (const feature of featuresUnique) {
     const versionsRange = feature.values
       ? ''

--- a/typings/index-template.d.ts
+++ b/typings/index-template.d.ts
@@ -189,6 +189,8 @@ export interface IndexedData {
   mapIconsArray: MapIcon[]
 
   tints: Tints
+
+  supportFeature: <T extends keyof SupportsFeature>(key: T) => SupportsFeature[T]
 }
 
 const versions: {

--- a/typings/test-typings.ts
+++ b/typings/test-typings.ts
@@ -19,6 +19,11 @@ console.log(getMcData.postNettyVersionsByProtocolVersion['pc'][47][0])
 
 console.log(getMcData(47).version)
 
+const supportFeature: boolean = getMcData('1.8.8').supportFeature('mobSpawner')
+console.log(supportFeature)
+const supportFeature2: 'string' | 'short' = getMcData('1.8.8').supportFeature('typeOfValueForEnchantLevel')
+console.log(supportFeature2)
+
 console.log(getMcData('1.8').version)
 
 console.log(getMcData('15w40b').version)


### PR DESCRIPTION
I see this repository frequently updated so I''ll prioritize any requests from here.

I'm more interested in the interface I'll be using in my application than the actual type of the `supportFeature` function. This is what I want to be able to do:

```ts
import minecraftData, { SupportsFeature } from 'minecraft-data'

const getSupportFeaturesMap = (version: string) => {
    const supportsFeature = minecraftData(version).supportFeature
    
    return new Proxy({} as SupportsFeature, {
        get: (target, name) => {
            if (typeof name === 'string') {
                return supportsFeature(version, name)
            }
            return undefined
        }
    })
}

// than do
if (supportsFeature.someThing) { // ...
```

This thing would give really good intellisense along with descriptions and concise code, so maybe there is a chance I can add it as well?

---

I don't really know how features.json is generated, but why there are duplicating entries like `dimensionDataIsAvailable`?

UPDATE: I also can suggest to use [code-block-writer](https://www.npmjs.com/package/code-block-writer) in case if generator becomes big