### PR TITLE
Fix Version Typing

### DIFF
--- a/typings/index-template.d.ts
+++ b/typings/index-template.d.ts
@@ -11,7 +11,9 @@ export interface Version {
   ['=='](other: string): boolean
   type: 'pc' | 'bedrock'
   version?: number
-  majorVersion: string
+  dataVersion?: number
+  majorVersion?: string
+  minecraftVersion?: string
 }
 
 export interface VersionSet {

--- a/typings/index-template.d.ts
+++ b/typings/index-template.d.ts
@@ -10,6 +10,8 @@ export interface Version {
   // Returns true if the current version is equal to the `other` version's dataVersion
   ['=='](other: string): boolean
   type: 'pc' | 'bedrock'
+  version?: number
+  majorVersion: string
 }
 
 export interface VersionSet {

--- a/typings/index-template.d.ts
+++ b/typings/index-template.d.ts
@@ -194,7 +194,7 @@ export interface IndexedData {
 }
 
 const versions: {
-  [key in keyof SupportedVersions]: Version[]
+  [key in keyof SupportedVersions]: ProtocolVersions
 }
 const versionsByMinecraftVersion: VersionSet
 const preNettyVersionsByProtocolVersion: VersionSet


### PR DESCRIPTION
- Add missing properties to the `Version` function interface based on [the properties returned](https://github.com/PrismarineJS/node-minecraft-data/blob/58caf5b4cab2488b73adf588d9a8d10c1d08535c/index.js#L27). This now matches with the returned format of the type tests.
```
Version {
  dataVersion: undefined,
  '>=': [Function (anonymous)],
  '>': [Function (anonymous)],
  '<': [Function (anonymous)],
  '<=': [Function (anonymous)],
  '==': [Function (anonymous)],
  type: 'bedrock',
  majorVersion: '0.14',
  version: 70,
  minecraftVersion: '0.14.3'
}
```


- switched the `versions` variable to use type `ProtocolVersion` instead of `Version[]`. This matches with what `versions` is assigned to in [the code](https://github.com/PrismarineJS/node-minecraft-data/blob/58caf5b4cab2488b73adf588d9a8d10c1d08535c/index.js#L105C1-L105C1).
  - Note that ProtocolVersion is defined as an array of objects, so there is no need to write it as [].