### PR TITLE
fix strict null types & object type

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     ],
     "noImplicitAny": true,
     "noImplicitThis": true,
-    "strictNullChecks": false,
+    "strictNullChecks": true,
     "strictFunctionTypes": true,
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]

--- a/typings/index-template.d.ts
+++ b/typings/index-template.d.ts
@@ -1,3 +1,5 @@
+type Object = { [key: string]: any }
+
 export interface Version {
   // Returns true if the current version is greater than or equal to the `other` version's dataVersion
   ['>='](other: string): boolean
@@ -23,21 +25,21 @@ export interface SupportedVersions {
 }
 
 export interface Schemas {
-  biomes: object
-  blocks: object
-  effects: object
-  entities: object
-  instruments: object
-  items: object
-  materials: object
-  protocol: object
-  protocolVersions: object
-  recipes: object
-  version: object
-  windows: object
-  foods: object
-  blockLoot: object
-  entityLoot: object
+  biomes: Object
+  blocks: Object
+  effects: Object
+  entities: Object
+  instruments: Object
+  items: Object
+  materials: Object
+  protocol: Object
+  protocolVersions: Object
+  recipes: Object
+  version: Object
+  windows: Object
+  foods: Object
+  blockLoot: Object
+  entityLoot: Object
 }
 
 export interface LoginPacket {
@@ -61,9 +63,9 @@ export interface LoginPacket {
   /**
    * Introduced in Minecraft 1.17
    */
-  dimensionCodec?: object
+  dimensionCodec?: Object
 
-  dimension: object
+  dimension: Object
 
   /**
    * Introduced in Minecraft 1.17
@@ -92,14 +94,18 @@ export interface LoginPacket {
   isFlat?: boolean
 }
 
+type RequireOnly<T, K extends keyof T> = Partial<T> & Required<Pick<T, K>>
+
+type IndexedBlock = RequireOnly<Block, 'minStateId' | 'maxStateId' | 'defaultState'>
+
 export interface IndexedData {
   isOlderThan(version: string): boolean
   isNewerOrEqualTo(version: string): boolean
 
-  blocks: { [id: number]: Block }
-  blocksByName: { [name: string]: Block }
-  blocksByStateId: { [id: number]: Block }
-  blocksArray: Block[]
+  blocks: { [id: number]: IndexedBlock }
+  blocksByName: { [name: string]: IndexedBlock }
+  blocksByStateId: { [id: number]: IndexedBlock }
+  blocksArray: IndexedBlock[]
   blockMappings: {
     pc: { name: string, states: Record<string, string | number> },
     pe: { name: string, states: Record<string, string | number> }
@@ -107,7 +113,7 @@ export interface IndexedData {
   /**
    * Bedrock edition only
    */
-  blockStates?: { name: string; states: object; version: number }[]
+  blockStates?: { name: string; states: Object; version: number }[]
   blockCollisionShapes: { blocks: { [name: string]: number[] }; shapes: { [id: number]: [number[]] } }
 
   loginPacket: LoginPacket
@@ -144,10 +150,10 @@ export interface IndexedData {
   /**
    * Bedrock edition only
    */
-  defaultSkin?: object
+  defaultSkin?: Object
 
-  protocol: object
-  protocolComments: object
+  protocol: Object
+  protocolComments: Object
   /**
    * Bedrock edition only
    */

--- a/typings/test-typings.ts
+++ b/typings/test-typings.ts
@@ -28,6 +28,10 @@ console.log(getMcData('0.30c').version)
 console.log(getMcData('bedrock_0.14').version)
 
 console.log(getMcData('pc_1.9').blocksByName['dirt'])
+console.log(getMcData('pc_1.9').blocksByName['dirt'].minStateId.toExponential)
+
+console.log(getMcData('pc_1.9').protocol.toClient)
+
 console.log(getMcData('bedrock_0.14').blocksByName['podzol'])
 console.log(getMcData('bedrock_0.14').type)
 


### PR DESCRIPTION
1. Remove usage of `object` type because With Record<string, any>, you can access any property on the object without TypeScript complaining, because it's assumed that the object can have any string as a key with any type of value. With object, TypeScript doesn't allow you to access any properties on the object directly, because it doesn't know what properties the object has.

2. This node wrapper is always adding `minStateId`, `maxStateId`, and `defaultState`, that's why they should be required: https://github.com/zardoy/node-minecraft-data/blob/542925dfcabdecbfe0556db54530fc806827c302/lib/indexes.js#L7