### PR TITLE
fix(types): do not make properties of the block optional

### DIFF
--- a/typings/index-template.d.ts
+++ b/typings/index-template.d.ts
@@ -98,9 +98,9 @@ export interface LoginPacket {
   isFlat?: boolean
 }
 
-type RequireOnly<T, K extends keyof T> = Partial<T> & Required<Pick<T, K>>
+type MakeRequired<T, K extends keyof T> = T & Required<Pick<T, K>>
 
-type IndexedBlock = RequireOnly<Block, 'minStateId' | 'maxStateId' | 'defaultState'>
+type IndexedBlock = MakeRequired<Block, 'minStateId' | 'maxStateId' | 'defaultState'>
 
 export interface IndexedData {
   isOlderThan(version: string): boolean

--- a/typings/test-typings.ts
+++ b/typings/test-typings.ts
@@ -34,6 +34,7 @@ console.log(getMcData('bedrock_0.14').version)
 
 console.log(getMcData('pc_1.9').blocksByName['dirt'])
 console.log(getMcData('pc_1.9').blocksByName['dirt'].minStateId.toExponential)
+console.log(getMcData('pc_1.9').blocksByName['dirt'].name.includes)
 
 console.log(getMcData('pc_1.9').protocol.toClient)
 


### PR DESCRIPTION
i have no idea what was the point of making all the properties of the block optional, fixed