### PR TITLE
Add test for version comparison with and without dataVersion

### DIFF
--- a/test/version_compare.js
+++ b/test/version_compare.js
@@ -1,0 +1,19 @@
+/* global describe, it */
+const assert = require('assert')
+const mcData = require('../index')
+
+describe('Version Comparison', () => {
+  it('should correctly compare versions with and without dataVersion', () => {
+    const version = new mcData.Version('pc', '1.7.10')
+
+    // Test case from issue #399
+    assert.strictEqual(version['<=']('1.7.10'), true, '1.7.10 should be <= 1.7.10')
+    assert.strictEqual(version['<']('1.8'), true, '1.7.10 should be < 1.8')
+    assert.strictEqual(version['<=']('1.8'), true, '1.7.10 should be <= 1.8')
+
+    // Additional test cases
+    assert.strictEqual(version['>']('1.7.2'), true, '1.7.10 should be > 1.7.2')
+    assert.strictEqual(version['>=']('1.7.2'), true, '1.7.10 should be >= 1.7.2')
+    assert.strictEqual(version['==']('1.7.10'), true, '1.7.10 should be == 1.7.10')
+  })
+})


### PR DESCRIPTION
This commit introduces a new test file `test/version_compare.js` to specifically test the version comparison logic, particularly for scenarios involving versions with and without `dataVersion`.

The test case covers the issue described in #399, ensuring that comparisons like `version['<=']('1.7.10')` and `version['<']('1.8')` work correctly for version 1.7.10.

(built by jules)