### PR TITLE
Update wrapper data for Minecraft 26.1.2

### DIFF
--- a/bin/ensure_minecraft_data.js
+++ b/bin/ensure_minecraft_data.js
@@ -20,7 +20,7 @@ fs.rmSync('minecraft-data', { recursive: true, force: true })
 const clone = spawnSync('git', ['clone', '--depth', '1', '--filter=blob:none', '--sparse', '--branch', dataBranch, dataRepo, 'minecraft-data'], { stdio: 'inherit' })
 if (clone.status !== 0) process.exit(clone.status || 1)
 
-const sparse = spawnSync('git', ['-C', 'minecraft-data', 'sparse-checkout', 'set', 'data'], { stdio: 'inherit' })
+const sparse = spawnSync('git', ['-C', 'minecraft-data', 'sparse-checkout', 'set', 'data', 'schemas'], { stdio: 'inherit' })
 if (sparse.status !== 0) process.exit(sparse.status || 1)
 
 if (!fs.existsSync(dataPaths)) {

--- a/bin/ensure_minecraft_data.js
+++ b/bin/ensure_minecraft_data.js
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+
+const fs = require('fs')
+const { spawnSync } = require('child_process')
+
+if (fs.existsSync('minecraft-data/data/dataPaths.json')) process.exit(0)
+
+const result = spawnSync('git', ['submodule', 'update', '--init', '--recursive'], { stdio: 'inherit' })
+if (result.status !== 0) process.exit(result.status || 1)

--- a/bin/ensure_minecraft_data.js
+++ b/bin/ensure_minecraft_data.js
@@ -3,7 +3,27 @@
 const fs = require('fs')
 const { spawnSync } = require('child_process')
 
-if (fs.existsSync('minecraft-data/data/dataPaths.json')) process.exit(0)
+const dataPaths = 'minecraft-data/data/dataPaths.json'
+const dataRepo = 'https://github.com/mneuhaus/minecraft-data.git'
+const dataBranch = 'pc_26_1_2'
 
-const result = spawnSync('git', ['submodule', 'update', '--init', '--recursive'], { stdio: 'inherit' })
-if (result.status !== 0) process.exit(result.status || 1)
+if (fs.existsSync(dataPaths)) process.exit(0)
+
+if (fs.existsSync('.git')) {
+  const result = spawnSync('git', ['submodule', 'update', '--init', '--recursive'], { stdio: 'inherit' })
+  if (result.status !== 0) process.exit(result.status || 1)
+  if (fs.existsSync(dataPaths)) process.exit(0)
+}
+
+fs.rmSync('minecraft-data', { recursive: true, force: true })
+
+const clone = spawnSync('git', ['clone', '--depth', '1', '--filter=blob:none', '--sparse', '--branch', dataBranch, dataRepo, 'minecraft-data'], { stdio: 'inherit' })
+if (clone.status !== 0) process.exit(clone.status || 1)
+
+const sparse = spawnSync('git', ['-C', 'minecraft-data', 'sparse-checkout', 'set', 'data'], { stdio: 'inherit' })
+if (sparse.status !== 0) process.exit(sparse.status || 1)
+
+if (!fs.existsSync(dataPaths)) {
+  console.error(`Could not load ${dataPaths}`)
+  process.exit(1)
+}

--- a/bin/ensure_minecraft_data.js
+++ b/bin/ensure_minecraft_data.js
@@ -11,8 +11,7 @@ if (fs.existsSync(dataPaths)) process.exit(0)
 
 if (fs.existsSync('.git')) {
   const result = spawnSync('git', ['submodule', 'update', '--init', '--recursive'], { stdio: 'inherit' })
-  if (result.status !== 0) process.exit(result.status || 1)
-  if (fs.existsSync(dataPaths)) process.exit(0)
+  if (result.status === 0 && fs.existsSync(dataPaths)) process.exit(0)
 }
 
 fs.rmSync('minecraft-data', { recursive: true, force: true })

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test:types": "tsc typings/test-typings && node typings/test-typings.js",
     "test": "npm run generate:types && npm run generate:data && npm run lint && npm run test:types && mocha",
     "lint": "standard",
-    "prepare": "npm run generate:data && npm run generate:types",
+    "prepare": "node ./bin/ensure_minecraft_data.js && npm run generate:data && npm run generate:types",
     "fix": "standard --fix"
   },
   "standard": {


### PR DESCRIPTION
## Summary

Updates the node-minecraft-data wrapper to point at the generated Minecraft 26.1.2 data.

This depends on the minecraft-data 26.1.2 data PR and is part of the downstream protocol/Mineflayer compatibility chain.

## Testing

Validated locally with:

- npm test
- 499255 OKs
- 865 passing

Evidence summary: https://gist.github.com/mneuhaus/decaae9cd8767a651272d31cdf97ac60

## Related PRs

Part of the Minecraft 26.1.2 update chain:

1. PrismarineJS/minecraft-jar-extractor#67 - nested item model extraction support
2. PrismarineJS/minecraft-assets#48 - generated 26.1.2 assets
3. PrismarineJS/node-minecraft-assets#52 - assets wrapper update
4. PrismarineJS/minecraft-data#1186 - 26.1.2 protocol/data plus generated block/item data
5. PrismarineJS/node-minecraft-data#455 - wrapper update for the generated data
6. PrismarineJS/node-minecraft-protocol#1487 - 26.1.2 protocol support/tests
7. PrismarineJS/prismarine-chunk#326 - 26.1.2 chunk fluid count support
8. PrismarineJS/prismarine-physics#134 - 26.1 physics feature flags
9. PrismarineJS/mineflayer#3902 - full Mineflayer external-suite compatibility
10. PrismarineJS/prismarine-viewer#480 - 26.1.2 viewer support

The dependent PRs are opened as drafts so they can be reviewed/merged in order.

## Implementation note

Prepared with assistance from GPT-5.5 and validated locally with the checks listed above.