### PR TITLE
loader: pass tags through to mcData

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -226,6 +226,19 @@ console.log(mcData.materials['mineable/axe'])
 // Returns: { '702': 2, '707': 4, '712': 12, '717': 6, '722': 8, '727': 9 }
 ```
 
+## Tags
+
+### mcData.tags
+
+Registry tags indexed by registry kind (`block`, `item`, `fluid`, `entity_type`), then by namespaced tag name. Tag members are entry names with nested `#tag` references already flattened. `undefined` for versions without tags data.
+
+Example:
+
+```js
+console.log(mcData.tags.block['minecraft:mineable/pickaxe'])
+// Returns: [ 'minecraft:stone', 'minecraft:granite', ... ]
+```
+
 ## Entities
 
 ### mcData.mobs

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -85,6 +85,8 @@ function mcDataToNode (mcData) {
 
     sounds: indexes.soundsById,
     soundsByName: indexes.soundsByName,
-    soundsArray: mcData.sounds
+    soundsArray: mcData.sounds,
+
+    tags: mcData.tags
   }
 }

--- a/test/load.js
+++ b/test/load.js
@@ -54,6 +54,29 @@ describe('versions with block data have block state IDs', () => {
   })
 })
 
+describe('versions with tags data expose them as registry->tag->members', () => {
+  const mcData = require('minecraft-data')
+  const versions = require('minecraft-data').versions
+  let withTags = 0
+  for (const type in versions) {
+    for (const version of versions[type]) {
+      it(type + ' ' + version.minecraftVersion, () => {
+        const data = mcData(type + '_' + version.minecraftVersion)
+        if (!data || data.tags === undefined) return
+        withTags++
+        for (const registry in data.tags) {
+          for (const tag in data.tags[registry]) {
+            assert.ok(Array.isArray(data.tags[registry][tag]), `${registry} ${tag} should map to an array`)
+          }
+        }
+      })
+    }
+  }
+  after(() => {
+    console.log(withTags, 'versions with tags data')
+  })
+})
+
 describe('supportFeature', () => {
   it('dimensionIsAnInt is only accessible in 1.8 - 1.15.2', () => {
     const mcData1Dot9 = require('minecraft-data')('1.9')

--- a/typings/index-template.d.ts
+++ b/typings/index-template.d.ts
@@ -144,6 +144,11 @@ export interface IndexedData {
 
   materials: { [name: string]: Material }
 
+  /**
+   * Registry tags keyed by registry kind (block, item, fluid, entity_type), then by namespaced tag name. undefined for versions without tags data
+   */
+  tags?: { [registry: string]: { [tagName: string]: string[] } }
+
   mobs: { [id: number]: Entity }
   objects: { [id: number]: Entity }
   entities: { [id: number]: Entity }

--- a/typings/test-typings.ts
+++ b/typings/test-typings.ts
@@ -5,6 +5,7 @@ console.log(mcData.blocksByName['stone'])
 console.log(mcData.windows['minecraft:brewing_stand'])
 console.log(mcData.version)
 console.log(mcData.effectsByName['Haste'])
+console.log(mcData.tags?.block['minecraft:mineable/pickaxe'])
 
 console.log(mcData.mobs[62])
 console.log(mcData.objects[62])


### PR DESCRIPTION
## Summary

Implements the loader half discussed in PrismarineJS/minecraft-data#412 and resolves #315 (block tags feature request, 2023): `lib/loader.js` returns a fixed object and never passed `tags` through, so `mcData.tags` (and `registry.tags` downstream) stayed `undefined` even once tags data exists. This adds the passthrough.

`bin/generate_data.js` already builds `data.js` getters from every `dataPaths` key, so the data side needs no change here — the loader's return object was the only gap. With the current submodule pin no version has tags data, so `mcData.tags` is `undefined` everywhere: this merges green now, stays inert, and activates automatically on the next submodule bump after minecraft-data#1080 (+ its schema) land.

## Changes

- `lib/loader.js` — `tags: mcData.tags` passthrough. Plain map like `materials`; no id index applies (tags are already name-keyed).
- `typings/index-template.d.ts` — `tags?: { [registry: string]: { [tagName: string]: string[] } }`. Structural type for now; once the tags schema is in the submodule, the generated `Tags` interface (the typings generator walks `schemas/`) can replace it.
- `doc/api.md` — `mcData.tags` section with the `undefined`-when-absent caveat.
- `test/load.js` — per-version shape contract: `tags` is either `undefined` or registry → tag → array. Currently exercises the `undefined` path on every version; picks up real data automatically on bump.

## Verified locally

- Full `npm test` chain green with the change (generate:types, generate:data, lint, test:types, mocha — 1,735 passing).
- End-to-end simulation of the post-#1080 world: with that PR's `tags.json` + `dataPaths` entry applied to the submodule and `generate:data` re-run, `require('minecraft-data')('1.21.8').tags` returns the full object (194 block / 179 item / 2 fluid / 39 entity_type tags; `minecraft:diamond_ore` resolvable through both `minecraft:mineable/pickaxe` and `minecraft:needs_iron_tool` — the minecraft-data#987 case), while `('1.21.1').tags` and `('bedrock_1.18.0').tags` stay `undefined`. No loader re-touch needed at bump time.

## Out of scope

- A tag-based `digTime()`/harvest path in prismarine-block. That needs a design decision on where tool-tier speeds live (see minecraft-data#412); this PR only makes the data reachable so that discussion can happen against something concrete.
- The module-level `schemas` export in `index.js` and swapping the structural typing for the generated `Tags` interface — both need the tags schema present in the submodule, so they belong in a follow-up after the first post-schema submodule bump.
